### PR TITLE
Update to postgis 3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM postgres:14-bullseye
 MAINTAINER Network Reconnaissance Lab <baker@cs.uky.edu>
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.1.4+dfsg-3.pgdg110+1
+ENV POSTGIS_VERSION 3.2.0+dfsg-1.pgdg110+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \


### PR DESCRIPTION
Postgis 3.2.0 has been released: https://www.postgis.net/2021/12/18/postgis-3.2.0/