### PR TITLE
ci: Bump to Postgis to 3.5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM postgres:17-bullseye
 
 LABEL maintainer="HIPAA Postgres w/ PostGIS Project" \
-      org.opencontainers.image.description="PostGIS 3.5.1+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 17 bullseye" \
+      org.opencontainers.image.description="PostGIS 3.5.2+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 17 bullseye" \
       org.opencontainers.image.source="https://github.com/netreconlab/hipaa-postgres/"
 
 ENV POSTGIS_MAJOR=3
-ENV POSTGIS_VERSION=3.5.1+dfsg-1.pgdg110+1
+ENV POSTGIS_VERSION=3.5.2+dfsg-1.pgdg110+1
 ENV POSTGRES_INITDB_ARGS="--data-checksums"
 
 RUN apt-get update \

--- a/Dockerfile.pgpool
+++ b/Dockerfile.pgpool
@@ -1,11 +1,11 @@
 FROM postgres:17-bullseye
 
 LABEL maintainer="HIPAA Postgres w/ PostGIS Project" \
-      org.opencontainers.image.description="PostGIS 3.5.1+dfsg-1.pgdg110+1 spatial database extension and PGPool with PostgreSQL 17 bullseye" \
+      org.opencontainers.image.description="PostGIS 3.5.2+dfsg-1.pgdg110+1 spatial database extension and PGPool with PostgreSQL 17 bullseye" \
       org.opencontainers.image.source="https://github.com/netreconlab/hipaa-postgres/"
 
 ENV POSTGIS_MAJOR=3
-ENV POSTGIS_VERSION=3.5.1+dfsg-1.pgdg110+1
+ENV POSTGIS_VERSION=3.5.2+dfsg-1.pgdg110+1
 ENV POSTGRES_INITDB_ARGS="--data-checksums"
 
 RUN apt-get update \


### PR DESCRIPTION
- [x] Update to Postgis 3.5.2, see https://postgis.net/2025/01/PostGIS-3.5.2/